### PR TITLE
Menu entry for Spyke Viewer

### DIFF
--- a/xdg/desktop/neurodebian-spykeviewer.desktop
+++ b/xdg/desktop/neurodebian-spykeviewer.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=Spyke Viewer
+GenericName=Graphical utility for analyzing electrophysiological data
+Exec=nd-autoinstall spykeviewer
+Type=Application
+Terminal=false
+Categories=X-NeuroDebian-Electrophysiology
+Icon=spykeviewer.png


### PR DESCRIPTION
This inserts a Spyke Viewer entry into the applications menu under "NeuroDebian/Electrophysiology" that installs / starts the program.
