### PR TITLE
BF: nd-configurepo was not correctly obtaining the key if gpg was not present

### DIFF
--- a/tools/nd-configurerepo
+++ b/tools/nd-configurerepo
@@ -571,7 +571,7 @@ if [ "$ae_update" = "1" ]; then
     print_verbose 1 "Updating APT listings, might take a few minutes"
     if [ -z "$ae_dry_run" ]; then
         apt_logfile="$ae_tempdir/apt.log"
-        $ae_sudo apt-get update 1>"$apt_logfile" 2>&1 \
+        $ae_sudo apt-get update --no-allow-insecure-repositories 1>"$apt_logfile" 2>&1 \
             && rm -f "$apt_logfile" \
             || {
                  apt_log=$(cat "$apt_logfile")
@@ -585,7 +585,7 @@ if [ "$ae_update" = "1" ]; then
                  error 5 "Update failed with exit code $?."
                  }
     else
-        eval_dry apt-get update
+        eval_dry apt-get update --no-allow-insecure-repositories
     fi
 else
     print_verbose 1 "apt-get update  was not run. Please run to take an effect of changes"

--- a/tools/nd-configurerepo
+++ b/tools/nd-configurerepo
@@ -571,7 +571,7 @@ if [ "$ae_update" = "1" ]; then
     print_verbose 1 "Updating APT listings, might take a few minutes"
     if [ -z "$ae_dry_run" ]; then
         apt_logfile="$ae_tempdir/apt.log"
-        $ae_sudo apt-get update --no-allow-insecure-repositories 1>"$apt_logfile" 2>&1 \
+        $ae_sudo apt-get update 1>"$apt_logfile" 2>&1 \
             && rm -f "$apt_logfile" \
             || {
                  apt_log=$(cat "$apt_logfile")
@@ -585,7 +585,7 @@ if [ "$ae_update" = "1" ]; then
                  error 5 "Update failed with exit code $?."
                  }
     else
-        eval_dry apt-get update --no-allow-insecure-repositories
+        eval_dry apt-get update # --no-allow-insecure-repositories
     fi
 else
     print_verbose 1 "apt-get update  was not run. Please run to take an effect of changes"

--- a/tools/nd-configurerepo
+++ b/tools/nd-configurerepo
@@ -2,7 +2,11 @@
 #emacs: -*- mode: shell-script; c-basic-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
 #ex: set sts=4 ts=4 sw=4 et:
 
-# Depends:    apt (assumed to be present), python, wget
+# Depends:
+#   assumes to be present:
+#     apt
+#   installs if needed if NEURODEBIAN_INSTALL=1:
+#     python, wget, gnupg, dirmngr (when older gnupg)
 # Recommends: netselect
 
 # play safe
@@ -545,6 +549,14 @@ fi
 
 # Figure out if key needs to be imported (if ran within package,
 # should already be there due to neurodebian-archive-keyring package)
+
+# Ideas taken from neurodebian-docker setup to guarantee correct apt-key functioning
+# gnupg needed by apt-key might not yet be installed
+assure_command_from_package gpg gnupg 1
+# Ubuntu includes "gnupg" (not "gnupg2", but still 2.x), but not dirmngr, and gnupg 2.x requires dirmngr
+# so, if we're not running gnupg 1.x, explicitly install dirmngr too
+gpg --version | grep -q '^gpg (GnuPG) 1\.' || assure_command_from_package dirmngr dirmngr 1
+
 if LANG=C eval $ae_sudo apt-key export $nd_key_id 2>&1 1>/dev/null | grep -qe "nothing exported"; then
     print_verbose 1 "Fetching the key from the server"
     eval_dry apt-key adv --recv-keys --keyserver pgp.mit.edu $nd_key_id


### PR DESCRIPTION
Detected in minimalistic debootstrapped (singularity) images, while

Also originally added fortification of `apt-get update` run (if it is done) to not allow insecure repositories, 
 but will disable it now since if users run on their already insecure apt setups, why should we be more stringent?