### PR TITLE
nd_freeze: remove apt list files if there were none to start with

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,8 +6,7 @@ Uploaders: Michael Hanke <mih@debian.org>, Yaroslav Halchenko <debian@onerussian
 Build-Depends: debhelper (>= 9~), xcftools, help2man, inkscape, imagemagick, python-html5lib, po-debconf
 Standards-Version: 3.9.8
 Homepage: http://neuro.debian.net
-Vcs-Browser: http://git.debian.org/?p=pkg-exppsy/neurodebian.git
-Vcs-Git: git://git.debian.org/git/pkg-exppsy/neurodebian.git
+Vcs-Git: https://salsa.debian.org/neurodebian-team/neurodebian.git
 
 Package: neurodebian
 Architecture: all
@@ -78,7 +77,7 @@ Description: neuroscience-oriented distribution - GnuPG archive keys
 
 Package: neurodebian-freeze
 Architecture: all
-Depends: perl-base
+Depends: ${misc:Depends},
 Description: nd_freeze tool to freeze APT sources to use snapshots
  The NeuroDebian project integrates and maintains a variety of software
  projects within Debian that are useful for neuroscience (such as AFNI,

--- a/tools/nd_freeze
+++ b/tools/nd_freeze
@@ -364,6 +364,11 @@ if (! -e '/etc/apt/apt.conf.d/10no--check-valid-until') {
     qx!echo 'Acquire::Check-Valid-Until "0";' > /etc/apt/apt.conf.d/10no--check-valid-until!;
 }
 
+# So we later on could make a decision either we need to clean up after ourselves
+# Rely on having a Release file, since cannot be just * since there could be
+# empty partial/ directory
+my @apt_releases_list = </var/lib/apt/lists/*Release>;
+
 my $user_timestamp = get_user_timestamp($USER_DATE);
 my $snapshots_sources_file = '/etc/apt/sources.list.d/snapshots.sources.list';
 my @sources_files = ('/etc/apt/sources.list', '/etc/apt/sources.list.d/neurodebian.sources.list');
@@ -384,10 +389,15 @@ if ((keys %sources) > 0) {
         foreach my $sources_file (@sources_files) {
             disable_lines($sources_file, %sources) if (-e $sources_file);
         }
-        run_apt_get_update();
+        run_apt_get_update();  # run even only to check and then cleanup later on
     }
 } else {
     info "No valid sources found to get snapshots.";
+}
+
+if (scalar @apt_releases_list == 0) {
+	   info "Cleaning up APT lists because originally there were none";
+	   rm -rf /var/lib/apt/lists/*;
 }
 
 exit 0

--- a/tools/nd_freeze
+++ b/tools/nd_freeze
@@ -396,8 +396,8 @@ if ((keys %sources) > 0) {
 }
 
 if (scalar @apt_releases_list == 0) {
-	   info "Cleaning up APT lists because originally there were none";
-	   rm -rf /var/lib/apt/lists/*;
+	info "Cleaning up APT lists because originally there were none";
+	qx!rm -rf /var/lib/apt/lists/*!;
 }
 
 exit 0

--- a/tools/nd_freeze
+++ b/tools/nd_freeze
@@ -1,4 +1,6 @@
 #!/usr/bin/perl
+#emacs: -*- mode: shell-script; c-basic-offset: 4; tab-width: 4; indent-tabs-mode: t -*-
+#ex: set sts=4 ts=4 sw=4 noet:
 #
 # Install access to the NeuroDebian snapshot repository that allows access
 # to old packages based on dates and version numbers.

--- a/tools/tests/test_nd_freeze
+++ b/tools/tests/test_nd_freeze
@@ -124,9 +124,9 @@ assert_line_in_file "snapshots.sources.list" "deb http://snapshot.debian.org/arc
 assert_line_in_file "sources.list" "# deb http://deb.debian.org/debian jessie main"
 assert_line_in_file "sources.list" "# deb http://security.debian.org" "partial_match"
 assert_line_in_file "sources.list" "# deb http://deb.debian.org/debian jessie-updates main"
-assert_line_in_file "sources.list.original" "deb http://deb.debian.org/debian jessie main"
-assert_line_in_file "sources.list.original" "deb http://security.debian.org" "partial_match"
-assert_line_in_file "sources.list.original" "deb http://deb.debian.org/debian jessie-updates main"
+assert_line_in_file "sources.list.orig.disabled" "deb http://deb.debian.org/debian jessie main"
+assert_line_in_file "sources.list.orig.disabled" "deb http://security.debian.org" "partial_match"
+assert_line_in_file "sources.list.orig.disabled" "deb http://deb.debian.org/debian jessie-updates main"
 assert_line_in_file "stdout" "INFO: Cleaning up APT lists because originally there were none" "partial_match"
 assert_line_in_file "lists_file_count" "1"
 test_teardown

--- a/tools/tests/test_nd_freeze
+++ b/tools/tests/test_nd_freeze
@@ -55,6 +55,7 @@ function test_setup {
         if [ -f /etc/apt/sources.list.d/snapshots.sources.list ]; then
             cp /etc/apt/sources.list.d/snapshots.sources.list /temp/snapshots.sources.list
         fi
+        ls -l /var/lib/apt/lists | wc -l > /temp/lists_file_count
     '"
     eval "$cmd" | tee $TMP_DIR/stdout
     ret=$?
@@ -126,6 +127,8 @@ assert_line_in_file "sources.list" "# deb http://deb.debian.org/debian jessie-up
 assert_line_in_file "sources.list.original" "deb http://deb.debian.org/debian jessie main"
 assert_line_in_file "sources.list.original" "deb http://security.debian.org" "partial_match"
 assert_line_in_file "sources.list.original" "deb http://deb.debian.org/debian jessie-updates main"
+assert_line_in_file "stdout" "INFO: Cleaning up APT lists because originally there were none" "partial_match"
+assert_line_in_file "lists_file_count" "1"
 test_teardown
 
 echo "[ Test handling of a different release ]"


### PR DESCRIPTION
To ease application in docker files IMHO we should clean up after ourselves -- if there were no apt list files to start with, we should remove them when we are done to minimize impact on that FS layer in docker. Original motivator was a comment on neurodebian/dockerfiles initial pull request: https://github.com/neurodebian/dockerfiles/pull/11#discussion_r232094692

Attn: @mjtravers - please review and if you could add a test for that -- would be great!