### PR TITLE
ENH: Added downgrading of packages for nd_freeze

### DIFF
--- a/tools/nd_freeze
+++ b/tools/nd_freeze
@@ -43,7 +43,10 @@ use Socket;
 # 
 sub info {
     my ($output) = @_;
-    print "INFO: ${output}\n";
+    my @lines = split /\n/, $output;
+    foreach my $line (@lines) { 
+        print "INFO: ${line}\n";
+    }
 }
 
 # Function gets the page contents of the provided URL.
@@ -82,9 +85,9 @@ sub get_www_content {
 sub run_apt_get_update {
     info "Refreshing apt cache";
     if (qx!grep ubuntu /etc/os-release!) {
-        print qx/apt-get update --no-allow-insecure-repositories/;
+        info qx/apt-get update --no-allow-insecure-repositories/;
     } else {
-        print qx/apt-get update/;
+        info qx/apt-get update/;
     }
 }
 
@@ -339,6 +342,68 @@ sub disable_lines {
 }
 
 
+# Get a list of the installed packages
+# 
+# Returns
+# ----------
+# @packages
+#     array : Names of the installed packages
+#
+sub installed_packages {
+ 
+    info "Discovering installed packages for possible version downgrades";
+    my @packages = ();
+    my @lines = split /\n/, qx/dpkg -l/;
+    for my $i (0 .. $#lines) {
+        my @chunks = split /\s+/, $lines[$i];
+        push @packages, $chunks[1] if ($chunks[0] eq 'ii');
+    }
+
+    return @packages;
+}
+
+
+# Downgrade the installed packages to their snapshot versions
+#
+# Parameters
+# ----------
+# @packages
+#     array : List of installed packages
+#
+sub downgrade_packages {
+    my (@packages) = @_;
+
+    for my $package (@packages) {
+        info "Checking package '${package}' for an older snapshot version";
+        my $found = 0;
+        my $installed_version = '';
+        my $snapshot_version = '';
+        my @lines = split /\n/, qx/apt-cache policy $package/;
+        for my $i (0 .. $#lines) {
+            $installed_version = $1 if ($lines[$i] =~ /Installed:\s+(\S+)/);
+            if ($lines[$i] =~ /snapshot\.debian\.org|snapshot\-neuro\.debian\.net/) {
+                my @chunks = split /\s+/, $lines[$i-1];
+                $snapshot_version = $chunks[1];
+                $found = 1 if ($snapshot_version ne '***');
+                last;
+            }
+        }
+        if ($found) {
+            if ($package eq 'libc-bin' or $package =~ /gcc-[\d\.]+-base/) {
+                # TODO: Handle the very bad things that happen when these packages are downgraded.
+                info "SKIPPING downgrade of ${package} to version ${snapshot_version} due to technical difficulties."
+            }
+            else {
+                $pipe_command = "echo 'Yes, do as I say!' |";
+                info "DOWNGRADING '${package}=${installed_version}' to version '${snapshot_version}'";
+                info qx/${pipe_command} apt-get install --no-install-recommends --force-yes -y ${package}=${snapshot_version}/;
+            }
+        }
+    }
+
+}
+
+
 ##### Program main
 
 # Parse command line options
@@ -386,6 +451,14 @@ if ((keys %sources) > 0) {
     }
 } else {
     info "No valid sources found to get snapshots.";
+}
+
+if ($KEEP_SOURCES) {
+    info "Packages were not downgraded";
+}
+else {
+    my @packages = installed_packages();
+    downgrade_packages(@packages);
 }
 
 exit 0

--- a/tools/tests/test_nd_freeze
+++ b/tools/tests/test_nd_freeze
@@ -126,6 +126,8 @@ assert_line_in_file "sources.list" "# deb http://deb.debian.org/debian jessie-up
 assert_line_in_file "sources.list.orig.disabled" "deb http://deb.debian.org/debian jessie main"
 assert_line_in_file "sources.list.orig.disabled" "deb http://security.debian.org" "partial_match"
 assert_line_in_file "sources.list.orig.disabled" "deb http://deb.debian.org/debian jessie-updates main"
+assert_line_in_file "stdout" "INFO: DOWNGRADING 'gcc-4.9-base:amd64=4.9.2-10+deb8u1' to version '4.9.2-10'"
+assert_line_in_file "stdout" "INFO: DOWNGRADING 'ncurses-base=5.9+20140913-1+deb8u3' to version '5.9+20140913-1'"
 test_teardown
 
 echo "[ Test handling of a different release ]"
@@ -181,6 +183,7 @@ assert_line_in_file "snapshots.sources.list" "deb http://snapshot.debian.org/arc
 assert_line_in_file "sources.list" "deb http://deb.debian.org/debian jessie main"
 assert_line_in_file "sources.list" "deb http://security.debian.org" "partial_match"
 assert_line_in_file "sources.list" "deb http://deb.debian.org/debian jessie-updates main"
+assert_line_in_file "stdout" "INFO: Packages were not downgraded" "partial_match"
 test_teardown
 
 exit $EXIT_CODE


### PR DESCRIPTION
This is working although ___very bad things___ happen when downgrading certain packages such as libc-bin (wheezy) and gcc-4.9-base:amd64 (jessie). When the system hangs, it is complains about not finding the PAM security profile which I assume is getting deleted during the downgrade. For now, the user is alerted that nd_freeze could but is not going to downgrade problematic packages and then moves on to the next package to downgrade.

Here is the output for the libc-bin downgrade fail:

> Removing apt ...
> Removing bash ...
> Removing base-files ...
> Removing base-passwd ...
> Removing bsdutils ...
> Removing e2fsprogs ...
> Removing util-linux ...
> update-alternatives: using /usr/bin/pg to provide /usr/bin/pager (pager) in auto mode
> Removing sysvinit ...
> Removing initscripts ...
> Removing coreutils ...
> Removing dash ...
> Removing 'diversion of /bin/sh to /bin/sh.distrib by dash'
> Removing iputils-ping ...
> Removing libssl1.0.0:amd64 ...
> Removing tzdata ...
> Removing sysv-rc ...
> Removing mount ...
> Removing libmount1 ...
> Removing libblkid1:amd64 ...
> Removing libuuid1:amd64 ...
> Removing passwd ...
> Removing login ...
> Removing libpam-runtime ...
> PAM configuration
> -----------------
> 
> No PAM profiles have been selected.
> 
> No PAM profiles have been selected for use on this system.  This would grant all
> users access without authenticating, and is not allowed.  Please select at least
> one PAM profile from the available list.

Here is the output for the failed gcc-4.9-base:amd64 fail:

> Removing init (1.22) ...
> Removing systemd-sysv (215-17+deb8u7) ...
> Removing systemd (215-17+deb8u7) ...
> Removing acl (2.2.52-2) ...
> Removing udev (215-17+deb8u7) ...
> Removing adduser (3.113+nmu3) ...
> Removing apt (1.0.9.8.4) ...
> dpkg: warning: overriding problem because --force enabled:
> dpkg: warning: this is an essential package; it should not be removed
> Removing bash (4.3-11+deb8u1) ...
> dpkg: warning: overriding problem because --force enabled:
> dpkg: warning: this is an essential package; it should not be removed
> Removing base-files (8+deb8u11) ...
> dpkg: warning: while removing base-files, unable to remove directory '/dev': Device or resource busy - directory may be a mount point?
> dpkg: warning: while removing base-files, unable to remove directory '/proc': Device or resource busy - directory may be a mount point?
> dpkg: warning: overriding problem because --force enabled:
> dpkg: warning: this is an essential package; it should not be removed
> Removing base-passwd (3.5.37) ...
> dpkg: warning: overriding problem because --force enabled:
> dpkg: warning: this is an essential package; it should not be removed
> Removing bsdutils (1:2.25.2-6) ...
> Removing procps (2:3.3.9-9+deb8u1) ...
> /usr/sbin/invoke-rc.d: 1: /usr/sbin/invoke-rc.d: /sbin/runlevel: not found
> invoke-rc.d: policy-rc.d denied execution of stop.
> Removing libcryptsetup4:amd64 (2:1.6.6-5) ...
> dpkg: warning: overriding problem because --force enabled:
> dpkg: warning: this is an essential package; it should not be removed
> dpkg: warning: overriding problem because --force enabled:
> dpkg: warning: this is an essential package; it should not be removed
> dpkg: warning: overriding problem because --force enabled:
> dpkg: warning: this is an essential package; it should not be removed
> Removing dash (0.5.7-4+b1) ...
> Removing 'diversion of /bin/sh to /bin/sh.distrib by dash'
> dpkg-divert: error: rename involves overwriting `/bin/sh' with
>  different file `/bin/sh.distrib', not allowed
> dpkg: error processing package dash (--remove):
> subprocess installed pre-removal script returned error exit status 2
> debconf: unable to initialize frontend: Dialog
> debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
> debconf: falling back to frontend: Readline
> debconf: unable to initialize frontend: Readline
> debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC contains: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.20.2 /usr/local/share/perl/5.20.2 /usr/lib/x86_64-linux-gnu/perl5/5.20 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.20 /usr/share/perl/5.20 /usr/local/lib/site_perl .) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 7.)
> debconf: falling back to frontend: Teletype
> dpkg: warning: overriding problem because --force enabled:
> dpkg: warning: this is an essential package; it should not be removed
> dpkg: warning: overriding problem because --force enabled:
> dpkg: warning: this is an essential package; it should not be removed
> Removing login (1:4.2-3+deb8u4) ...
> Removing libpam-runtime (1.1.8-3.1+deb8u2) ...
> debconf: unable to initialize frontend: Dialog
> debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
> debconf: falling back to frontend: Readline
> debconf: unable to initialize frontend: Readline
> debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC contains: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.20.2 /usr/local/share/perl/5.20.2 /usr/lib/x86_64-linux-gnu/perl5/5.20 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.20 /usr/share/perl/5.20 /usr/local/lib/site_perl .) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 7.)
> debconf: falling back to frontend: Teletype
> PAM configuration
> -----------------
> 
> No PAM profiles have been selected.
> 
> No PAM profiles have been selected for use on this system.  This would grant all users access without authenticating, and is not allowed.  Please select at
> least one PAM profile from the available list.
> 
