### PR TITLE
BF: Switched source discovery from apt-cache to using /var/lib/apt/li…

### DIFF
--- a/tools/nd_freeze
+++ b/tools/nd_freeze
@@ -63,6 +63,7 @@ sub logg {
     }
 }
 
+
 # Function gets the page contents of the provided URL.
 #
 # Parameters
@@ -96,14 +97,32 @@ sub get_www_content {
 }
 
 
+# Run a shell command
+#
+# Parameters
+# ----------
+# $command
+#   string : command to run in shell
+#
+sub exec_shell {
+    my $command = shift;
+    logg("debug", "Executing shell command: '$command'");
+    my $stdout = qx!$command!;
+    if ($?) {
+        logg("info", "Command '$command' failed.");
+        exit $?;
+    }
+    logg("debug", split(/\n/, $stdout));
+    return $stdout;
+}
+
+
 # Function to run apt-get update
 sub run_apt_get_update {
     logg("info", "Refreshing apt cache");
-    if (qx!grep ubuntu /etc/os-release!) {
-        logg("debug", qx/apt-get update --no-allow-insecure-repositories/);
-    } else {
-        logg("debug", qx/apt-get update/);
-    }
+    my $switch = "";
+    $switch = "--no-allow-insecure-repositories" if (is_minimum_apt_version("1.4.8"));
+    exec_shell("apt-get update $switch");
 }
 
 
@@ -273,7 +292,6 @@ sub write_snapshot_sources {
         my $domain = 'snapshot-neuro.debian.net:5002';
         $domain = 'snapshot.debian.org' if ($sources{$key}{Origin} eq 'Debian');
         my $label = lc($sources{$key}{Label});
-        logg("debug", "Finding snapshot at http://$domain for $user_timestamp");
         $contents = get_www_content("http://${domain}/archive/${label}/${user_timestamp}/");
         # Handle 404 redirect page not found.
         if ($contents =~ /HTTP\/1.1 404 Not Found/) {
@@ -293,7 +311,11 @@ sub write_snapshot_sources {
             logg("info", "WARNING: User specified time (${user_timestamp}) later than latest snapshot available (${next_timestamp}). Skipping archive http://${domain}/archive/${label}/${next_timestamp}/");
             next;
         }
-        print $fp "deb http://${domain}/archive/${label}/${next_timestamp}/ ${sources{$key}{Codename}} ${sources{$key}{Component}}\n";
+        # Hold off updating security archive until after the debian-archive-keyring package is updated.
+        my $line_prefix = "";
+        $line_prefix = "#" if ($sources{$key}{Label} eq 'Debian-Security');
+
+        print $fp "${line_prefix}deb http://${domain}/archive/${label}/${next_timestamp}/ ${sources{$key}{Codename}} ${sources{$key}{Component}}\n";
         logg("debug", "Adding 'deb http://${domain}/archive/${label}/${next_timestamp}/ ${sources{$key}{Codename}} ${sources{$key}{Component}}' to $snapshots_sources_file");
         $found_count += 1;
     }
@@ -315,7 +337,7 @@ sub write_snapshot_sources {
 sub disable_lines {
     my ($sources_file, %sources) = @_;
 
-    qx/cp $sources_file ${sources_file}.orig.disabled/ if (!-e "${sources_file}.orig.disabled");
+    exec_shell("cp $sources_file ${sources_file}.orig.disabled") if (!-e "${sources_file}.orig.disabled");
 
     open my $in, '<', "${sources_file}.orig.disabled"
         or die "Could not open file '${sources_file}.orig.disabled' $!";
@@ -375,7 +397,7 @@ sub installed_packages {
  
     logg("info", "Discovering installed packages for possible version downgrades");
     my @packages = ();
-    my @lines = split /\n/, qx/dpkg -l/;
+    my @lines = split /\n/, exec_shell("dpkg -l");
     for my $i (0 .. $#lines) {
         my @chunks = split /\s+/, $lines[$i];
         push @packages, $chunks[1] if ($chunks[0] eq 'ii');
@@ -400,7 +422,7 @@ sub downgrade_packages {
         my $found = 0;
         my $installed_version = '';
         my $snapshot_version = '';
-        my @lines = split /\n/, qx/apt-cache policy $package/;
+        my @lines = split /\n/, exec_shell("apt-cache policy $package");
         for my $i (0 .. $#lines) {
             $installed_version = $1 if ($lines[$i] =~ /Installed:\s+(\S+)/);
             if ($lines[$i] =~ /snapshot\.debian\.org|snapshot\-neuro\.debian\.net/) {
@@ -418,7 +440,30 @@ sub downgrade_packages {
 
     my $packages_to_downgrade = join " ", @downgrade_packages;
     logg("info", "DOWNGRADING: ${packages_to_downgrade}");
-    logg("debug", qx/export DEBIAN_FRONTEND=noninteractive; apt-get install --no-install-recommends --force-yes -y ${packages_to_downgrade}/);
+    my $downgrade_switch = "--force-yes";
+    $downgrade_switch = "--allow-downgrades" if (is_minimum_apt_version("1.1.57"));
+    exec_shell("export DEBIAN_FRONTEND=noninteractive; apt-get install --no-install-recommends $downgrade_switch -y ${packages_to_downgrade}");
+}
+
+# Test system for minimum version of apt package
+#
+# Parameters
+# ----------
+# $version
+#     string : version number to test
+#
+# Returns
+# -------
+# boolean : true if system version is >= to the parameter version
+#
+sub is_minimum_apt_version {
+    my $version = shift;
+    my $result = exec_shell("dpkg -l apt");
+    $result =~ /ii\s+apt\s+(\S+)/;
+    logg("debug", "Found apt version $1");
+    my $version_test = exec_shell("dpkg --compare-versions $1 ge $version && echo 1 || echo 0");
+    $version_test =~ /(\d+)/;
+    return $1;
 }
 
 
@@ -446,7 +491,7 @@ $USER_DATE = $ARGV[$parameter_count - 1];
 
 # Set apt setting to allow "outdated" repositories.
 if (! -e '/etc/apt/apt.conf.d/10no--check-valid-until') {
-    qx!echo 'Acquire::Check-Valid-Until "0";' > /etc/apt/apt.conf.d/10no--check-valid-until!;
+    exec_shell("echo 'Acquire::Check-Valid-Until \"0\";' > /etc/apt/apt.conf.d/10no--check-valid-until");
 }
 
 # So we later on could make a decision either we need to clean up after ourselves
@@ -460,10 +505,10 @@ my @sources_files = ('/etc/apt/sources.list', '/etc/apt/sources.list.d/neurodebi
 
 # Restore original sources files and apt-cache if this is a rerun of the command.
 foreach my $sources_file (@sources_files) {
-    qx/cp ${sources_file}.orig.disabled $sources_file/ if (-e "${sources_file}.orig.disabled");
+    exec_shell("cp ${sources_file}.orig.disabled $sources_file") if (-e "${sources_file}.orig.disabled");
 }
 if (-e $snapshots_sources_file) {
-    qx/rm $snapshots_sources_file/;
+    exec_shell("rm $snapshots_sources_file");
     run_apt_get_update();
 }
 
@@ -483,15 +528,23 @@ if ((keys %sources) > 0) {
 
 if ($DO_NOT_DOWNGRADE) {
     logg("info", "Packages were not downgraded");
+    # Enable security archives
+    exec_shell("sed -i 's:#::g' $snapshots_sources_file");
 }
 else {
+    # Update debian-archive-keyring first
+    downgrade_packages(("debian-archive-keyring"));
+    # Enable security archives
+    exec_shell("sed -i 's:#::g' $snapshots_sources_file");
+    run_apt_get_update();
+    # Downgrade all the packages
     my @packages = installed_packages();
     downgrade_packages(@packages);
 }
 
 if (scalar @apt_releases_list == 0) {
 	logg("info", "Cleaning up APT lists because originally there were none");
-	qx!rm -rf /var/lib/apt/lists/*!;
+	exec_shell("rm -rf /var/lib/apt/lists/*");
 }
 
 exit 0

--- a/tools/nd_freeze
+++ b/tools/nd_freeze
@@ -209,39 +209,33 @@ Valid date formats include:
 # 
 sub get_sources {
     my %sources;
-    my @lines = split /\n/, qx/apt-cache policy/;
-    # Check to see if we need to update the cache before checking the policy.
-    if ($#lines < 5) {
-        run_apt_get_update();
-        @lines = split /\n/, qx/apt-cache policy/;
-    }
     logg("info", "Discovering installed repository sources");
-    for my $i (0 .. $#lines) {
-        if ($lines[$i] =~ /(http\S+)\s+([\w-\/]+)\/([\w\-]+)/) {
-            my $url = $1;
-            chop($url) if (substr($url, -1) eq '/');
-            my $repo = '';
-            my $archive = $2;
-            my $type = $3;
-            $lines[$i+1] =~ /o=(\w+),/;
-            my $domain = $1;
-            $repo = 'debian' if ($domain eq 'Debian');
-            $repo = 'debian-security' if ($domain eq 'Debian' && $url =~ 'security');
-            $repo = 'neurodebian' if ($domain eq 'NeuroDebian');
-            if ($domain ne "Ubuntu") { # Skip Ubuntu repos because there are no snapshots available.
-                logg("debug", "Found $domain archive $archive at $url");
-                my $key = "$domain|$repo|$archive";
-                if (exists $sources{$key}) {
-                    $sources{$key}{type} .= " $type";
-                } else {
-                    %{$sources{$key}} = (
-                        domain => $domain,
-                        repo => $repo,
-                        archive => $archive,
-                        type => $type,
-                        url => $url
-                    );
+    run_apt_get_update();
+    my @files = glob("/var/lib/apt/lists/*Release");
+    for my $file (@files) {
+        my %source;
+        open my $fh, '<', $file or die "Could not open '$file' $!\n";
+        while (my $line = <$fh>) {
+            chomp $line;
+            if ($line =~ /^([a-zA-Z][^:]*):[\ ]+(\S.*)$/) {
+                $source{$1} = $2;
+            }
+        }
+        if ($source{Origin} eq "Debian" or $source{Origin} eq "NeuroDebian") {
+            logg("debug", "Found $source{Label} $source{Codename} with components $source{Components}");
+            for my $component (split(' ', $source{Components})) {
+                my $codename = $source{Codename};
+                if ($component =~ /(\S+)\/(\S+)/) {
+                    $codename = "${source{Codename}}/${1}";
+                    $component = $2;
                 }
+                my $key = "$source{Label}|$source{Codename}|$component";
+                %{$sources{$key}} = (
+                    Origin => $source{Origin},
+                    Label => $source{Label},
+                    Codename => $codename,
+                    Component => $component
+                );
             }
         }
     }
@@ -261,7 +255,8 @@ sub get_sources {
 # $user_timestamp
 #     string : Timestamp of freeze date provided by user at the command line.
 # %sources
-#     hash : The sources retrieved from apt-cache policy that need to be written to the sources file.
+#     hash : The sources retrieved from /var/lib/apt/lists/*Release policy that
+#            need to be written to the sources file.
 #
 sub write_snapshot_sources {
     my ($snapshots_sources_file, $user_timestamp, %sources) = @_;
@@ -269,36 +264,37 @@ sub write_snapshot_sources {
     my $found_count = 0;
     open my $fp, '>', $snapshots_sources_file;
     for my $key (keys %sources) {
-        if ($sources{$key}{domain} eq 'NeuroDebian' and !$have_knocked) {
+        if ($sources{$key}{Origin} eq 'NeuroDebian' and !$have_knocked) {
             # Knock on snapshot's door. This is temporarily necessary until the production
             # version of the site is made available.
             get_www_content('http://neuro.debian.net/_files/knock-snapshots');
             $have_knocked = 1;
         }
         my $domain = 'snapshot-neuro.debian.net:5002';
-        $domain = 'snapshot.debian.org' if ($sources{$key}{domain} eq 'Debian');
+        $domain = 'snapshot.debian.org' if ($sources{$key}{Origin} eq 'Debian');
+        my $label = lc($sources{$key}{Label});
         logg("debug", "Finding snapshot at http://$domain for $user_timestamp");
-        $contents = get_www_content("http://${domain}/archive/${sources{$key}{repo}}/${user_timestamp}/");
+        $contents = get_www_content("http://${domain}/archive/${label}/${user_timestamp}/");
         # Handle 404 redirect page not found.
         if ($contents =~ /HTTP\/1.1 404 Not Found/) {
-            logg("info", "Can't find snapshot for http://${domain}/archive/${sources{$key}{repo}}/${user_timestamp}");
+            logg("info", "Can't find snapshot for http://${domain}/archive/${label}/${user_timestamp}");
             next;
         }
         # Handle 301 redirect from snapshot server if we get one.
-        if ($contents =~ /The resource has been moved to http:\/\/[\S\-]+\/archive\/${sources{$key}{repo}}\/(\d{8}T\d{6}Z\/)/) {
-            $contents = get_www_content("http://${domain}/archive/${sources{$key}{repo}}/${1}/");
+        if ($contents =~ /The resource has been moved to http:\/\/[\S\-]+\/archive\/${label}\/(\d{8}T\d{6}Z\/)/) {
+            $contents = get_www_content("http://${domain}/archive/${label}/${1}/");
         }
         # Scrape next timestamp from HTML returned from snapshot server.
-        $contents =~ /\/archive\/${sources{$key}{repo}}\/([0-9TZ]+)\/">next</;
+        $contents =~ /\/archive\/${label}\/([0-9TZ]+)\/">next</;
         my $next_timestamp = $1;
         $next_timestamp =~ tr/\///d;
         if ($user_timestamp gt $next_timestamp) {
             # Notify user that they have requested a date beyond the most recent snapshot.
-            logg("info", "WARNING: User specified time (${user_timestamp}) later than latest snapshot available (${next_timestamp}). Skipping archive http://${domain}/archive/${sources{$key}{repo}}/${next_timestamp}/");
+            logg("info", "WARNING: User specified time (${user_timestamp}) later than latest snapshot available (${next_timestamp}). Skipping archive http://${domain}/archive/${label}/${next_timestamp}/");
             next;
         }
-        print $fp "deb http://${domain}/archive/${sources{$key}{repo}}/${next_timestamp}/ ${sources{$key}{archive}} ${sources{$key}{type}}\n";
-        logg("debug", "Adding 'deb http://${domain}/archive/${sources{$key}{repo}}/${next_timestamp}/ ${sources{$key}{archive}} ${sources{$key}{type}}' to $snapshots_sources_file");
+        print $fp "deb http://${domain}/archive/${label}/${next_timestamp}/ ${sources{$key}{Codename}} ${sources{$key}{Component}}\n";
+        logg("debug", "Adding 'deb http://${domain}/archive/${label}/${next_timestamp}/ ${sources{$key}{Codename}} ${sources{$key}{Component}}' to $snapshots_sources_file");
         $found_count += 1;
     }
     close $fp;
@@ -340,7 +336,17 @@ sub disable_lines {
         for my $key (keys %sources) {
             $_ =~ /(http:\S+)(.*)$/;
             $file_line = $1 . join ' ', sort split /\s+/, $2;
-            $source_line = $sources{$key}{url} . ' ' . join ' ', sort split /\s+/, "$sources{$key}{archive} $sources{$key}{type}";
+            my $url;
+            if ($sources{$key}{Label} eq "Debian") {
+                $url = "http://deb.debian.org/debian";
+            }
+            elsif ($sources{$key}{Label} eq "Debian-Security") {
+                $url = "http://security.debian.org/debian-security";
+            }
+            elsif ($sources{$key}{Label} eq "NeuroDebian") {
+                $url = "http://neuro.debian.net/debian";
+            }
+            $source_line = $url . ' ' . join ' ', sort split /\s+/, "$sources{$key}{Codename} $sources{$key}{Component}";
             if ($file_line eq $source_line) {
                 $found = 1;
                 last;
@@ -391,7 +397,6 @@ sub downgrade_packages {
     my @downgrade_packages;
 
     for my $package (@packages) {
-        logg("debug", "Checking package '${package}' for an older snapshot version");
         my $found = 0;
         my $installed_version = '';
         my $snapshot_version = '';
@@ -473,6 +478,7 @@ if ((keys %sources) > 0) {
     }
 } else {
     logg("info", "No valid sources found to get snapshots.");
+    exit 1;
 }
 
 if ($DO_NOT_DOWNGRADE) {

--- a/tools/tests/test_nd_freeze
+++ b/tools/tests/test_nd_freeze
@@ -195,7 +195,7 @@ assert_line_in_file "sources.list" "deb http://deb.debian.org/debian jessie main
 assert_line_in_file "sources.list" "deb http://security.debian.org"
 assert_line_in_file "sources.list" "deb http://deb.debian.org/debian jessie-updates main"
 assert_line_in_file "stdout" "DEBUG: Get:1 http://neuro.debian.net jessie InRelease"
-assert_line_in_file "stdout" "DEBUG: Finding snapshot at http://snapshot.debian.org for 20170727T000000Z"
+assert_line_in_file "stdout" "DEBUG: Found Debian-Security jessie"
 assert_line_in_file "stdout" "INFO: Packages were not downgraded"
 test_teardown
 


### PR DESCRIPTION
…sts/*Release files

fixes #46 

I am able to successfully install the apt sources files necessary and downgrade the needed packages into a Singularity image. Here's my test Singularity file:

```
Bootstrap:docker
From:neurodebian:buster

%files
	/home/matt/Documents/repronim/neurodebian/tools/nd_freeze /opt/nd_freeze

%post
	#echo "Configuring the environment"
	#apt-get -y update

	echo "Freezing the environment ---------------------------"
	/opt/nd_freeze --debug 2018/08/08

	# setup the container sources themselves
	#apt-get install -y eatmydata vim less devscripts

%runscript
	make linuxstandalone

%environments
	unset PYTHONPATH
```

However, when refreshing the apt cache after creating the snapshot sources files, I am seeing a couple of errors for the debian-security repo. Although, the downgrades look to have been executed okay it looks like there is a key issue:

```
INFO: Refreshing apt cache
W: GPG error: http://snapshot.debian.org/archive/debian-security/20180808T141609Z buster/updates InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 8B48AD6246925553
E: The repository 'http://snapshot.debian.org/archive/debian-security/20180808T141609Z buster/updates InRelease' is not signed.
DEBUG: Get:1 http://snapshot-neuro.debian.net:5002/archive/neurodebian/20180808T050502Z data InRelease [25.7 kB]
Get:2 http://snapshot-neuro.debian.net:5002/archive/neurodebian/20180808T050502Z buster InRelease [23.9 kB]
Get:3 http://snapshot.debian.org/archive/debian/20180808T024907Z buster-updates InRelease [47.6 kB]
Get:4 http://snapshot-neuro.debian.net:5002/archive/neurodebian/20180808T050502Z data/non-free amd64 Packages [5961 B]
Get:5 http://snapshot-neuro.debian.net:5002/archive/neurodebian/20180808T050502Z data/main amd64 Packages [6579 B]
Get:6 http://snapshot-neuro.debian.net:5002/archive/neurodebian/20180808T050502Z buster/contrib amd64 Packages [14.9 kB]
Get:7 http://snapshot-neuro.debian.net:5002/archive/neurodebian/20180808T050502Z buster/main amd64 Packages [54.4 kB]
Get:8 http://snapshot.debian.org/archive/debian-security/20180808T141609Z buster/updates InRelease [38.3 kB]
Get:9 http://snapshot-neuro.debian.net:5002/archive/neurodebian/20180808T050502Z buster/non-free amd64 Packages [7168 B]
Get:10 http://snapshot.debian.org/archive/debian/20180808T024907Z buster InRelease [150 kB]
Err:8 http://snapshot.debian.org/archive/debian-security/20180808T141609Z buster/updates InRelease
  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 8B48AD6246925553
Get:11 http://snapshot.debian.org/archive/debian/20180808T024907Z buster/main amd64 Packages [7555 kB]
Get:12 http://snapshot.debian.org/archive/debian/20180808T024907Z buster/contrib amd64 Packages [49.4 kB]
Get:13 http://snapshot.debian.org/archive/debian/20180808T024907Z buster/non-free amd64 Packages [78.0 kB]
```

