### PR TITLE
BF: Updated package updates to discern between 'downgrading' and 'upg…

### DIFF
--- a/tools/nd_freeze
+++ b/tools/nd_freeze
@@ -5,7 +5,7 @@
 # Install access to the NeuroDebian snapshot repository that allows access
 # to old packages based on dates and version numbers.
 #
-# Usage: nd_freeze [--keep-apt-sources|-k] [--no-downgrade|-n] date
+# Usage: nd_freeze [--keep-apt-sources --no-updates|-n] date
 #
 # The UTC date/time format sent to NeuroDebian to get the repo info is in the
 # format yyyymmddThhmmssz or yyymmdd. However, the script will handle and
@@ -32,8 +32,8 @@
 # the original, non-snapshot source active so that up-to-date packages can
 # still be installed.
 #
-# Setting the command line switch --no-downgrade or -n will skip the package
-# downgrade step leaving the system as is.
+# Setting the command line switch --no-updates or -n will skip the package
+# update step, leaving the system as is.
 #
 # Setting the command line switch --debug or -d will display debugging info
 # to the screen.
@@ -308,8 +308,8 @@ sub write_snapshot_sources {
         $next_timestamp =~ tr/\///d;
         if ($user_timestamp gt $next_timestamp) {
             # Notify user that they have requested a date beyond the most recent snapshot.
-            logg("info", "WARNING: User specified time (${user_timestamp}) later than latest snapshot available (${next_timestamp}). Skipping archive http://${domain}/archive/${label}/${next_timestamp}/");
-            next;
+            logg("info", "ERROR: User specified time (${user_timestamp}) later than latest snapshot available (${next_timestamp}). Freeze failed.");
+            exit(1);
         }
         # Hold off updating security archive until after the debian-archive-keyring package is updated.
         my $line_prefix = "";
@@ -395,7 +395,7 @@ sub disable_lines {
 #
 sub installed_packages {
  
-    logg("info", "Discovering installed packages for possible version downgrades");
+    logg("info", "Discovering installed packages for possible version updates");
     my @packages = ();
     my @lines = split /\n/, exec_shell("dpkg -l");
     for my $i (0 .. $#lines) {
@@ -407,16 +407,16 @@ sub installed_packages {
 }
 
 
-# Downgrade the installed packages to their snapshot versions
+# Update the installed packages to their snapshot versions
 #
 # Parameters
 # ----------
 # @packages
 #     array : List of installed packages
 #
-sub downgrade_packages {
+sub update_packages {
     my (@packages) = @_;
-    my @downgrade_packages;
+    my @update_packages;
 
     for my $package (@packages) {
         my $found = 0;
@@ -433,16 +433,21 @@ sub downgrade_packages {
             }
         }
         if ($found) {
-            logg("debug", "Will DOWNGRADE '${package}=${installed_version}' to version '${snapshot_version}'");
-            push @downgrade_packages, "${package}=${snapshot_version}";
+            my $version_test = exec_shell("dpkg --compare-versions ${snapshot_version} ge ${installed_version} && echo 1 || echo 0");
+            my $action = 'DOWNGRADE';
+            $action = 'UPGRADE' if ($version_test == 1);
+            logg("debug", "Will ${action} '${package}=${installed_version}' to version '${snapshot_version}'");
+            push @update_packages, "${package}=${snapshot_version}";
         }
     }
 
-    my $packages_to_downgrade = join " ", @downgrade_packages;
-    logg("info", "DOWNGRADING: ${packages_to_downgrade}");
-    my $downgrade_switch = "--force-yes";
-    $downgrade_switch = "--allow-downgrades" if (is_minimum_apt_version("1.1.57"));
-    exec_shell("export DEBIAN_FRONTEND=noninteractive; apt-get install --no-install-recommends $downgrade_switch -y ${packages_to_downgrade}");
+    if (scalar(@update_packages) > 0) {
+        my $packages_to_update = join " ", @update_packages;
+        logg("info", "UPDATING: ${packages_to_update}");
+        my $update_switch = "--force-yes";
+        $update_switch = "--allow-downgrades" if (is_minimum_apt_version("1.1.57"));
+        exec_shell("export DEBIAN_FRONTEND=noninteractive; apt-get install --no-install-recommends $update_switch -y ${packages_to_update}");
+    }
 }
 
 # Test system for minimum version of apt package
@@ -472,19 +477,19 @@ sub is_minimum_apt_version {
 # Global vars
 $USER_DATE = "";
 $KEEP_SOURCES = 0;
-$DO_NOT_DOWNGRADE = 0;
+$DO_NOT_UPDATE = 0;
 $DEBUG = 0;
 
 # Parse command line options
 foreach(@ARGV) {
     $KEEP_SOURCES = 1 if ($_ eq '--keep-apt-sources' or $_ eq '-k');
-    $DO_NOT_DOWNGRADE = 1 if ($_ eq '--no-downgrade' or $_ eq '-n');
+    $DO_NOT_UPDATE = 1 if ($_ eq '--no-updates' or $_ eq '-n');
     $DEBUG = 1 if ($_ eq '--debug' or $_ eq '-d');
 }
-my $parameter_count = 1 + $KEEP_SOURCES + $DO_NOT_DOWNGRADE + $DEBUG;
+my $parameter_count = 1 + $KEEP_SOURCES + $DO_NOT_UPDATE + $DEBUG;
 if (scalar(@ARGV) != $parameter_count) {
     print "Invalid command parameters\n";
-    print "USAGE: nd_freeze [--keep-apt-sources] [--no-downgrade] [--debug] date\n";
+    print "USAGE: nd_freeze [--keep-apt-sources] [--no-updates] [--debug] date\n";
     exit 1;
 }
 $USER_DATE = $ARGV[$parameter_count - 1];
@@ -526,20 +531,20 @@ if ((keys %sources) > 0) {
     exit 1;
 }
 
-if ($DO_NOT_DOWNGRADE) {
-    logg("info", "Packages were not downgraded");
+if ($DO_NOT_UPDATE) {
+    logg("info", "Packages were not updated");
     # Enable security archives
     exec_shell("sed -i 's:#::g' $snapshots_sources_file");
 }
 else {
     # Update debian-archive-keyring first
-    downgrade_packages(("debian-archive-keyring"));
+    update_packages(("debian-archive-keyring"));
     # Enable security archives
     exec_shell("sed -i 's:#::g' $snapshots_sources_file");
     run_apt_get_update();
-    # Downgrade all the packages
+    # Update all the packages
     my @packages = installed_packages();
-    downgrade_packages(@packages);
+    update_packages(@packages);
 }
 
 if (scalar @apt_releases_list == 0) {

--- a/tools/tests/test_nd_freeze
+++ b/tools/tests/test_nd_freeze
@@ -135,7 +135,7 @@ assert_line_in_file "sources.list" "# deb http://deb.debian.org/debian jessie-up
 assert_line_in_file "sources.list.orig.disabled" "deb http://deb.debian.org/debian jessie main"
 assert_line_in_file "sources.list.orig.disabled" "deb http://security.debian.org"
 assert_line_in_file "sources.list.orig.disabled" "deb http://deb.debian.org/debian jessie-updates main"
-assert_line_in_file "stdout" "INFO: DOWNGRADING: base-files=8+deb8u9 gcc-4.9-base:amd64=4.9.2-10"
+assert_line_in_file "stdout" "INFO: UPDATING: base-files=8+deb8u9 gcc-4.9-base:amd64=4.9.2-10"
 assert_line_in_file "stdout" "INFO: Cleaning up APT lists because originally there were none"
 assert_line_NOT_in_file "stdout" "DEBUG:"
 assert_line_in_file "lists_file_count" "1"
@@ -166,7 +166,7 @@ assert_line_in_file "neurodebian.sources.list" "deb http://neuro.debian.net/debi
 assert_line_in_file "sources.list" "deb http://deb.debian.org/debian jessie main"
 assert_line_in_file "sources.list" "deb http://deb.debian.org/debian jessie-updates main"
 assert_line_in_file "sources.list" "deb http://security.debian.org"
-assert_line_in_file "stdout" 'INFO: WARNING: User specified time (20280827T000000Z) later than latest snapshot available'
+assert_line_in_file "stdout" 'INFO: ERROR: User specified time (20280827T000000Z) later than latest snapshot available'
 test_teardown
 
 echo "[ Test Ubuntu release ]"
@@ -183,7 +183,7 @@ assert_line_in_file "sources.list" "deb http://security.ubuntu.com/ubuntu/ xenia
 test_teardown
 
 echo "[ Test with switches ]"
-test_setup "neurodebian" "jessie" "7/27/2017" "--keep-apt-sources --no-downgrade --debug"
+test_setup "neurodebian" "jessie" "7/27/2017" "--keep-apt-sources --no-updates --debug"
 assert_line_in_file "neurodebian.sources.list" "deb http://neuro.debian.net/debian jessie main"
 assert_line_in_file "neurodebian.sources.list" "deb http://neuro.debian.net/debian data main"
 assert_line_in_file "snapshots.sources.list" "deb http://snapshot-neuro.debian.net:5002/archive/neurodebian/20170727T050508Z/ jessie main"
@@ -196,7 +196,7 @@ assert_line_in_file "sources.list" "deb http://security.debian.org"
 assert_line_in_file "sources.list" "deb http://deb.debian.org/debian jessie-updates main"
 assert_line_in_file "stdout" "DEBUG: Get:1 http://neuro.debian.net jessie InRelease"
 assert_line_in_file "stdout" "DEBUG: Found Debian-Security jessie"
-assert_line_in_file "stdout" "INFO: Packages were not downgraded"
+assert_line_in_file "stdout" "INFO: Packages were not updated"
 test_teardown
 
 exit $EXIT_CODE


### PR DESCRIPTION
…rading'. Put a hard exit from script when the user requests a snapshot in the future that does not exist.

Fixes #56 #55 #53 

This PR:
- Changes the --no-downgrade switch to the more neutral --no-updates
- Discerns between "DOWNGRADE" and "UPGRADE" in the debug and info output
- Does not call apt install needlessly if there are no packages to update
- Puts a hard EXIT with message if the user requests a date without a valid snapshot


