### PR TITLE
update ustc mirror info

### DIFF
--- a/neurodebian.cfg
+++ b/neurodebian.cfg
@@ -1,7 +1,7 @@
 [mirrors]
 au = http://mirror.aarnet.edu.au/pub/neurodebian
 cn-bj1 = http://mirrors.tuna.tsinghua.edu.cn/neurodebian
-cn-bj2 = http://debian.ustc.edu.cn/neurodebian
+cn-hf = http://mirrors.ustc.edu.cn/neurodebian
 # cn-ln = http://mirrors.neusoft.edu.cn/neurodebian
 # Has been N/A for a while
 # cn-lz = http://mirror.lzu.edu.cn/neurodebian
@@ -21,7 +21,7 @@ us-tn = http://masi.vuse.vanderbilt.edu/neurodebian
 [mirror names]
 au = Australia (AARNET)
 cn-bj1 = China (Tsinghua University)
-cn-bj2 = China (University of Science and Technology)
+cn-hf = China (University of Science and Technology of China)
 # cn-ln = China (Neusoft University of Information)
 cn-lz = China (Lanzhou University)
 cn-zj = China (Zhejiang University)


### PR DESCRIPTION
On behalf of ustc mirror admin, we want to update the server info,

* The ustc mirror is located at Hefei, China.
* The official name for ustc is (U)niversity of (S)cience and (T)echnology of (C)hina.
* We have deprecated the debian.ustc.edu.cn domain 2 years ago (https://github.com/ustclug/discussions/issues/66)