### PR TITLE
New mirror: FZJ

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ BIGMESS_OPTS = -c neurodebian.cfg
 BIGMESS_CMD = PYTHONPATH=.:3rd/bigmess:$(PYTHONPATH) 3rd/bigmess/bin/bigmess
 BIGMESS = $(BIGMESS_CMD) $(BIGMESS_OPTS)
 
-# Lentghy one due to updatedb
+# Lengthy one due to updatedb
 all: updatedb upload-website mirmon
 # Quick one -- just rebuilds html if new changes and adjusts the status of the mirrors
 refresh: upload-website-stamp mirmon
@@ -78,7 +78,7 @@ upload-website: html
 	: # Touch stamp here so we get it updated on every upload
 	touch $@-stamp
 
-# call upload iff .git/index was modified, i.e. new changes got pulled in
+# call upload if .git/index was modified, i.e. new changes got pulled in
 upload-website-stamp: .git/index
 	$(MAKE) upload-website
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ as Ubuntu and other derivatives.  Please visit our
 
 # Related projects from the NeuroDebian authors
 
-- [Open Brain Constent](http://open-brain-consent.readthedocs.io) - samples
+- [Open Brain Consent](http://open-brain-consent.readthedocs.io) - samples
   and an ultimate wording for experiment participant consent forms to make
   open data sharing possible
 - [DataLad](http://datalad.org) - a data distribution and management

--- a/neurodebian.cfg
+++ b/neurodebian.cfg
@@ -6,6 +6,7 @@ cn-hf = http://mirrors.ustc.edu.cn/neurodebian
 # Has been N/A for a while
 # cn-lz = http://mirror.lzu.edu.cn/neurodebian
 cn-zj = http://mirrors.zju.edu.cn/neurodebian
+de-fzj = http://neurodebian.inm7.de/debian
 de-m = http://neurodebian.g-node.org
 de-md = http://neurodebian.ovgu.de/debian
 # Decomissioned
@@ -25,6 +26,7 @@ cn-hf = China (University of Science and Technology of China)
 # cn-ln = China (Neusoft University of Information)
 cn-lz = China (Lanzhou University)
 cn-zj = China (Zhejiang University)
+de-fzj = Germany (Jülich Research Centre)
 de-m = Germany (G-Node, LMU Munich)
 de-md = Germany (University of Magdeburg)
 # de-v = Germany (Nikolaus Valentin Haenel, Vogtland)


### PR DESCRIPTION
Add a NeuroDebian mirror hosted at Forschungszentrum Jülich.

This shouldn't be merged quite yet. I am still populating the mirror manually (from `neurodebian.ovgu.de`). 

Your scripts should rsync to `/var/www/neurodebian.inm7.de/www` (IIRC, those are private and not in this repo). I copied the `.ssh/authorized_keys` from `neurodebian.ovgu.de`, so auth should be good to go.

I'll let you know when the initial rsync is done. Let me know if I'm missing anything. :-)
