### PR TITLE
BF: react also to 302 and its message instead of 301 redirect

### DIFF
--- a/tools/nd_freeze
+++ b/tools/nd_freeze
@@ -300,12 +300,16 @@ sub write_snapshot_sources {
         $label =~ tr/ /-/;
         $contents = get_www_content("http://${domain}/archive/${label}/${user_timestamp}/");
         # Handle bad URL requests
-        if (!($contents =~ /^HTTP\/\d+\.\d+ 200/) and !($contents =~ /^HTTP\/\d+\.\d+ 301/)) {
+        if (!($contents =~ /^HTTP\/\d+\.\d+ 200/) and !($contents =~ /^HTTP\/\d+\.\d+ 30[12]/)) {
             $contents =~ /^(.+)/;
             die "Bad URL request http://${domain}/archive/${label}/${user_timestamp}/: ${1}\n";
         }
         # Handle 301 redirect from snapshot server if we get one.
         if ($contents =~ /The resource has been moved to http:\/\/[\S\-]+\/archive\/${label}\/(\d{8}T\d{6}Z\/)/) {
+            $contents = get_www_content("http://${domain}/archive/${label}/${1}/");
+        }
+		# It later became 302 with a different msg and only relative href
+        if ($contents =~ /You should be redirected automatically to target URL: .*\/archive\/${label}\/(\d{8}T\d{6}Z\/)<.*/) {
             $contents = get_www_content("http://${domain}/archive/${label}/${1}/");
         }
         # Scrape next timestamp from HTML returned from snapshot server.

--- a/tools/nd_freeze
+++ b/tools/nd_freeze
@@ -440,9 +440,15 @@ sub update_packages {
         my @lines = split /\n/, exec_shell("apt-cache policy $package");
         for my $i (0 .. $#lines) {
             $installed_version = $1 if ($lines[$i] =~ /Installed:\s+(\S+)/);
+            my @chunks = split /\s+/, $lines[$i];
+            # match by ensuring we deal with line having weight at the end
+            if ((($#chunks == 2)
+                 or ($#chunks == 3) && ($chunks[1] == '***'))
+                && ($chunks[-1] =~ /^[0-9]*$/)) {
+                   $snapshot_version = $chunks[1];
+            }
             if ($lines[$i] =~ /snapshot\.debian\.org|snapshot\-neuro\.debian\.net/) {
-                my @chunks = split /\s+/, $lines[$i-1];
-                $snapshot_version = $chunks[1];
+                # if already *** -- installed, not needed to upgrade/downgrade
                 $found = 1 if ($snapshot_version ne '***');
                 last;
             }

--- a/tools/nd_freeze
+++ b/tools/nd_freeze
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
-#emacs: -*- mode: shell-script; c-basic-offset: 4; tab-width: 4; indent-tabs-mode: t -*-
-#ex: set sts=4 ts=4 sw=4 noet:
+#emacs: -*- mode: shell-script; c-basic-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+#ex: set sts=4 ts=4 sw=4 et:
 #
 require 5.002;
 use Socket;
@@ -577,8 +577,8 @@ else {
 }
 
 if (scalar @apt_releases_list == 0) {
-	logg("info", "Cleaning up APT lists because originally there were none");
-	exec_shell("rm -rf /var/lib/apt/lists/*");
+    logg("info", "Cleaning up APT lists because originally there were none");
+    exec_shell("rm -rf /var/lib/apt/lists/*");
 }
 
 exit 0


### PR DESCRIPTION
Should fix invocations such as   nd_freeze 20220327 .

Ref 2 change of behavior: https://salsa.debian.org/snapshot-team/snapshot/-/merge_requests/2