### PR TITLE
Fixing support for installation on Github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,15 @@ jobs:
           cat /etc/apt/sources.list.d/neurodebian.sources.list
           ls -lR /etc/neurodebian
 
+  test-oneliner:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Test the ultimate one-liner setup for NeuroDebian repository
+        run: bash tools/neurodebian-github.sh
+
   test:
     runs-on: ubuntu-latest
     steps:
@@ -53,9 +62,6 @@ jobs:
         with:
           python-version: '^3.5'
 
-      - name: Test the ultimate one-liner setup for NeuroDebian repository
-        run: bash tools/neurodebian-github.sh
-      
       - name: Verify that we can install neurodebian using our tool
         run: |
           set -ex

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,15 +32,15 @@ jobs:
         if: failure()
         run: |
           set -ex
+          ls -lR /etc/apt || :
+          cat /etc/apt/sources.list.d/neurodebian.sources.list || :
+          ls -lR /etc/neurodebian || :
           # Could happen if installation of neurodebian package kills APT repo
           # so print policy
           sudo apt-cache policy
           # But could be that just update wasn't run?
           sudo apt-get update
           sudo apt-cache policy
-          ls -lR /etc/apt
-          cat /etc/apt/sources.list.d/neurodebian.sources.list
-          ls -lR /etc/neurodebian
 
   test-oneliner:
     runs-on: ubuntu-latest
@@ -85,12 +85,12 @@ jobs:
         if: failure()
         run: |
           set -ex
+          ls -lR /etc/apt || :
+          cat /etc/apt/sources.list.d/neurodebian.sources.list || :
+          ls -lR /etc/neurodebian || :
           # Could happen if installation of neurodebian package kills APT repo
           # so print policy
           sudo apt-cache policy
           # But could be that just update wasn't run?
           sudo apt-get update
           sudo apt-cache policy
-          ls -lR /etc/apt
-          cat /etc/apt/sources.list.d/neurodebian.sources.list
-          ls -lR /etc/neurodebian

--- a/tools/nd-configurerepo
+++ b/tools/nd-configurerepo
@@ -82,7 +82,7 @@ print_version()
     cat << EOT
 nd-configurerepo $nd_aptenable_version
 
-Copyright (C) 2014 Yaroslav Halchenko <debian@onerussian.com>
+Copyright (C) 2014-2023 Yaroslav Halchenko <debian@onerussian.com>
 
 Licensed under GNU Public License version 3 or later.
 This is free software; see the source for copying conditions.  There is NO
@@ -429,10 +429,16 @@ fi
 
 ae_output_file=/etc/apt/sources.list.d/neurodebian.sources${ae_suffix}.list
 
-apt_policy=$(get_apt_policy "Debian,Ubuntu" )
+# microsoft-ubuntu is the one since ~Aug 2023 is on GitHub actions, looks like
+#   500 https://packages.microsoft.com/ubuntu/22.04/prod jammy/main all Packages
+#       release o=microsoft-ubuntu-jammy-prod jammy,a=jammy,n=jammy,l=microsoft-ubuntu-jammy-prod jammy,c=main,b=all
+apt_policy=$(get_apt_policy "Debian,Ubuntu,microsoft-ubuntu" )
 
 if [ -z "$ae_release" ]; then
     ae_release=$(echo "$apt_policy" | head -1 | sed -e 's/.*,n=\([^,]*\),.*/\1/g')
+    if [ -z "$ae_release" ]; then
+        error 10 "Could not determine release from the following filtered apt policy output:\n$apt_policy"
+    fi
     if [ ! -z "$do_print_release" ]; then
         echo $ae_release
         exit 0


### PR DESCRIPTION
They started to use some custom APT repo with different origin

```
2023-08-25T21:37:14.1496114Z  500 https://packages.microsoft.com/ubuntu/22.04/prod jammy/main all Packages
2023-08-25T21:37:14.1496698Z      release o=microsoft-ubuntu-jammy-prod jammy,a=jammy,n=jammy,l=microsoft-ubuntu-jammy-prod jammy,c=main,b=all
```

and while at it, tuning up a little the testing workflow so we could test version as in here, not only as already shipped from the package in the distribution, which we know would not work here now :-/